### PR TITLE
Make browserSupport letter assignment a bit less hackish

### DIFF
--- a/chrome/content/scaffold/scaffold.js
+++ b/chrome/content/scaffold/scaffold.js
@@ -219,9 +219,9 @@ var Scaffold = new function() {
 		// get browser support
 		var browserSupport = translator.browserSupport;
 		if(!browserSupport) browserSupport = "g";
-		const browsers = ["gecko", "chrome", "safari", "ie", "bookmarklet", "server"];
-		for each(var browser in browsers) {
-			document.getElementById('checkbox-'+browser).checked = browserSupport.indexOf(browser[0]) !== -1;
+		const browsers = {gecko:"g", chrome:"c", safari:"s", ie:"i", bookmarklet:"b", server:"v"};
+		for (var browser in browsers) {
+			document.getElementById('checkbox-'+browser).checked = browserSupport.indexOf(browsers[browser]) !== -1;
 		}
 
 	}


### PR DESCRIPTION
Didn't notice that it wasn't actually working on the last commit
