### PR TITLE
Don't grab data from Import tab for Updates

### DIFF
--- a/chrome/content/scaffold/scaffold.js
+++ b/chrome/content/scaffold/scaffold.js
@@ -854,13 +854,11 @@ var Scaffold = new function() {
 		var me = this;
 		
 		if (test.type == "import") {
-			var input = _getImport();
-
 			test.items = [];
 
 			// Re-runs the test.
 			// TranslatorTester doesn't handle these correctly, so we do it manually
-			_run("doImport", input, null, function(obj, item) {
+			_run("doImport", test.input, null, function(obj, item) {
 				if(item) {
 					test.items.push(_sanitizeItem(item));
 				} 


### PR DESCRIPTION
Use what was stored in the translator.

I'm not sure why it was that way to start with, since test.input doesn't actually get updated in Tests, so you have to create a new translator if you want to change input.

Now we can do mass updates for Import translators. Before you had to click Edit Import and then Update for each.
