### PR TITLE
Show URL of active tab

### DIFF
--- a/chrome/content/scaffold/scaffold.js
+++ b/chrome/content/scaffold/scaffold.js
@@ -1096,10 +1096,14 @@ var Scaffold = new function() {
 	}
 
 	/*
-	 * updates list of available frames
+	 * updates list of available frames and show URL of active tab 
 	 */
 	function _updateFrames() {
 		var doc = _browser.document.getElementById("content").contentDocument;
+		
+		//Show URL of active tab
+		document.getElementById("textbox-tabUrl").value = doc.location.href;
+		
 		// No need to run if Scaffold isn't open
 		var menulist = _document.getElementById("menulist-testFrame");
 		if (!_document || !menulist) return true;

--- a/chrome/content/scaffold/scaffold.xul
+++ b/chrome/content/scaffold/scaffold.xul
@@ -173,6 +173,10 @@
 
 <vbox id="right-pane" flex="1">
 	
+	<hbox align="center">
+		<label control="textbox-tabUrl" id="label-tabUrl" value="&scaffold.tabUrl.label;"/>
+		<textbox id="textbox-tabUrl" flex="1"/>
+	</hbox>
 	<hbox id="hbox-testFrame" width="300">
 		<label control="menulist-testFrame" id="label-testFrame" value="&scaffold.testFrame.label;"/>
 		<menulist id="menulist-testFrame"/>

--- a/chrome/locale/en-US/scaffold/scaffold.dtd
+++ b/chrome/locale/en-US/scaffold/scaffold.dtd
@@ -12,6 +12,7 @@
 <!ENTITY scaffold.tabs.tests.label			"Tests">
 <!ENTITY scaffold.tabs.testing.label			"Testing">
 
+<!ENTITY scaffold.tabUrl.label			"Active Tab:">
 <!ENTITY scaffold.testFrame.label			"Test Frame:">
 
 <!ENTITY scaffold.metadata.translatorID.label		"Translator ID:">

--- a/chrome/locale/en-US/scaffold/scaffold.dtd
+++ b/chrome/locale/en-US/scaffold/scaffold.dtd
@@ -12,7 +12,7 @@
 <!ENTITY scaffold.tabs.tests.label			"Tests">
 <!ENTITY scaffold.tabs.testing.label			"Testing">
 
-<!ENTITY scaffold.tabUrl.label			"Active Tab:">
+<!ENTITY scaffold.tabUrl.label			"Active Tab URL:">
 <!ENTITY scaffold.testFrame.label			"Test Frame:">
 
 <!ENTITY scaffold.metadata.translatorID.label		"Translator ID:">


### PR DESCRIPTION
Pull request for #18.

I found some relevant documentation on XUL events at

* https://developer.mozilla.org/en-US/Add-ons/Code_snippets/Tabbed_browser#Manipulating_content_of_a_new_tab
* http://stackoverflow.com/questions/8355354/get-current-url-when-changing-tabs-in-xul-in-firefox

but it looks like things already work with the "pageshow" and "TabSelect" events that were already implemented for the `_updateFrames` function.