### PR TITLE
Make scaffold work with Zotero Standalone

### DIFF
--- a/src/chrome/content/scaffold/scaffold.xul
+++ b/src/chrome/content/scaffold/scaffold.xul
@@ -25,6 +25,7 @@
 -->
 <?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
 <?xml-stylesheet href="chrome://scaffold/skin/scaffold.css" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero-platform/content/overlay.css" type="text/css"?>
 
 <!DOCTYPE window SYSTEM "chrome://scaffold/locale/scaffold.dtd">
 
@@ -51,6 +52,13 @@
 		<toolbarbutton id="tb-detectImport" tooltiptext="&scaffold.toolbar.detectImport.label;" oncommand="Scaffold.run('detectImport')" />
 		<toolbarbutton id="tb-doImport" tooltiptext="&scaffold.toolbar.doImport.label;" oncommand="Scaffold.run('doImport')" />
 	</toolbar>
+	<tabbox id="scaffold-browser-tabbox" flex="1">
+        <tabs id="scaffold-browser-tabs">
+			<tab id="tab-scaffold" label="Scaffold"/>
+			<tab id="tab-browser" label="Browser"/>
+		</tabs>
+        <tabpanels flex="1">
+            <tabpanel flex="1" id="tabpanel-scaffold">
 <hbox flex="1">
 	<tabbox id="left-tabbox" flex="1" width="300">
 		<tabs id="tabs">
@@ -175,7 +183,7 @@
 	
 	<hbox align="center">
 		<label control="textbox-tabUrl" id="label-tabUrl" value="&scaffold.tabUrl.label;"/>
-		<textbox id="textbox-tabUrl" flex="1"/>
+		<textbox id="textbox-tabUrl" class="browser-url" flex="1"/>
 	</hbox>
 	<hbox id="hbox-testFrame" width="300">
 		<label control="menulist-testFrame" id="label-testFrame" value="&scaffold.testFrame.label;"/>
@@ -185,5 +193,19 @@
 	<textbox flex="1" id="output" multiline="true" readonly="true"/>
 </vbox>
 </hbox>
+</tabpanel>
+<tabpanel>
+	<vbox flex="1">
+		<hbox align="center">
+			<label control="textbox-tabUrl2" value="&scaffold.tabUrl.label;"/>
+			<textbox id="textbox-tabUrl2" class="browser-url" flex="1"/>
+		</hbox>
+		
+        <browser src="about:blank" flex="1"></browser>
+	</vbox>
+</tabpanel>
+</tabpanels>
+</tabbox>
+
 </vbox>
 </window>

--- a/src/chrome/locale/en-US/scaffold/scaffold.dtd
+++ b/src/chrome/locale/en-US/scaffold/scaffold.dtd
@@ -12,7 +12,7 @@
 <!ENTITY scaffold.tabs.tests.label			"Tests">
 <!ENTITY scaffold.tabs.testing.label			"Testing">
 
-<!ENTITY scaffold.tabUrl.label			"Active Tab URL:">
+<!ENTITY scaffold.tabUrl.label			"Current URL:">
 <!ENTITY scaffold.testFrame.label			"Test Frame:">
 
 <!ENTITY scaffold.metadata.translatorID.label		"Translator ID:">


### PR DESCRIPTION
Removes monitoring of active tab of the browser, since there is no
browser and adds a tab at the top of Scaffold to switch to a "browser" -
a frame with an url bar. The URL can also be entered in the Scaffold tab
where active URL is displayed (navigation on pressing `DOM_VK_RETURN`)

![image](https://user-images.githubusercontent.com/5899315/30740352-4bc6a8a0-9f99-11e7-9470-f231387de098.png)

Closes #36 