### PR TITLE
Remove Firefox from Target App

### DIFF
--- a/src/install.rdf
+++ b/src/install.rdf
@@ -12,14 +12,7 @@
     <em:updateURL>https://zotero.github.io/scaffold/scaffold.rdf</em:updateURL>
     <em:type>2</em:type> <!-- type=extension -->
     
-    <!-- Firefox -->
-    <em:targetApplication>
-      <Description>
-        <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
-        <em:minVersion>38.*</em:minVersion>
-        <em:maxVersion>43.*</em:maxVersion>
-      </Description>
-    </em:targetApplication>
+    <!-- Zotero -->
     
     <em:targetApplication>
       <Description>


### PR DESCRIPTION
a) this doesn't work anymore and
b) having two target apps breaks the current release script (which is of course fixable, but why bother)